### PR TITLE
Clean up login comment

### DIFF
--- a/pomodoro_app/auth/routes.py
+++ b/pomodoro_app/auth/routes.py
@@ -42,7 +42,7 @@ def login():
         user = User.query.filter_by(email=form.email.data.lower()).first()
         if user and check_password_hash(user.password, form.password.data):
             # Credentials valid – log in the user
-            login_user(user, remember=form.remember.data)  # create user session&#8203;:contentReference[oaicite:19]{index=19}
+            login_user(user, remember=form.remember.data)  # create user session
             # Redirect to next page if exists, or dashboard
             next_page = request.args.get('next')
             return redirect(next_page or url_for('main.dashboard'))


### PR DESCRIPTION
## Summary
- remove leftover content reference from login comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6867b24a58ac832ebc02ff96f8db051c