### PR TITLE
Add .env sample and test docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+FLASK_APP=pomodoro_app:create_app
+FLASK_ENV=development
+FLASK_CONFIG=development
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///pomodoro.db
+OPENAI_API_KEY=your_openai_key_here
+LOGGING_LEVEL=INFO
+RATELIMIT_STORAGE_URI=memory://
+TTS_ENABLED=true
+# Uncomment for production
+# REDIS_URL=redis://localhost:6379/0

--- a/README.txt
+++ b/README.txt
@@ -56,6 +56,9 @@ Installation:
    pip install -r requirements.txt
 
 4. Set Environment Variables:
+   # Use the provided sample file for local development
+   cp .env.example .env
+   # then edit .env with your settings, or export the variables manually:
    export FLASK_APP=pomodoro_app:create_app
    export FLASK_ENV=development
    export SECRET_KEY='your-very-secret-flask-key' # IMPORTANT: Set a strong secret key
@@ -79,6 +82,9 @@ Usage:
 - Start a Session: Use the Timer page to set your durations and start a Pomodoro.
 - View Analytics: Check the Dashboard for session statistics.
 - Chat (Optional): If configured, interact with the AI assistant on the dashboard.
+
+Running Tests:
+  pytest
 
 Contributing:
 Fork the repository, create a feature branch, commit your changes, and open a pull request.


### PR DESCRIPTION
## Summary
- provide `.env.example` with common environment variables
- explain using the sample file in the installation steps
- add section on how to run `pytest`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pomodoro_app')*

------
https://chatgpt.com/codex/tasks/task_e_6867eb691d48832e8dcee5b5a65600a9