### PR TITLE
Add dark theme toggle

### DIFF
--- a/pomodoro_app/static/js/theme_toggle.js
+++ b/pomodoro_app/static/js/theme_toggle.js
@@ -1,0 +1,25 @@
+(function() {
+  'use strict';
+  const toggleBtn = document.getElementById('theme-toggle');
+  if (!toggleBtn) return;
+
+  function applyTheme(theme) {
+    if (theme === 'dark') {
+      document.body.classList.add('dark-theme');
+      toggleBtn.textContent = 'Light Mode';
+    } else {
+      document.body.classList.remove('dark-theme');
+      toggleBtn.textContent = 'Dark Mode';
+    }
+  }
+
+  const stored = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  applyTheme(stored ? stored : (prefersDark ? 'dark' : 'light'));
+
+  toggleBtn.addEventListener('click', () => {
+    const newTheme = document.body.classList.contains('dark-theme') ? 'light' : 'dark';
+    applyTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+  });
+})();

--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -3,6 +3,17 @@ h1, h2, h3 {
   line-height: 1.3;
 }
 
+body {
+  background: #ffffff;
+  color: #212529;
+  line-height: 1.6;
+}
+
+body.dark-theme {
+  background: #121212;
+  color: #e9e9e9;
+}
+
 /* --- Dashboard Section Titles (secondary, not main) --- */
 .dashboard-section-title {
   color: #23272f;
@@ -702,7 +713,27 @@ h1, h2, h3 {
    .multiplier-rules-table tbody td {
        padding: 0.6em 0.5em;
    }
-   .multiplier-rules-table td:nth-child(3) { /* Details */
+  .multiplier-rules-table td:nth-child(3) { /* Details */
        font-size: 0.9em; /* Slightly smaller details on mobile */
    }
 }
+
+/* --- Dark Theme Overrides --- */
+body.dark-theme .navbar {
+  background: #222;
+}
+body.dark-theme .navbar .nav-links a { color: #ddd; }
+body.dark-theme .navbar .nav-links a:hover { color: #fff; }
+body.dark-theme .container {
+  background: transparent;
+}
+body.dark-theme #timer-component,
+body.dark-theme .stats-column,
+body.dark-theme .chat-agent-section,
+body.dark-theme .multiplier-rules-container {
+  background: #1e1e1e;
+  color: inherit;
+}
+body.dark-theme .status-message { background: #333; color: #eee; }
+body.dark-theme .multiplier-rules-table thead th { background: #2c2c2c; }
+body.dark-theme .multiplier-rules-table tbody tr:nth-child(even) { background: #2a2a2a; }

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -26,6 +26,7 @@
           <a href="{{ url_for('auth.register') }}">Register</a>
         {% endif %}
       </div>
+      <button id="theme-toggle" class="theme-toggle btn btn-sm">Dark Mode</button>
     </div>
   </nav>
 
@@ -54,5 +55,6 @@
     {% endwith %}
     {% block content %}{% endblock %}
   </div>
+  <script src="{{ url_for('static', filename='js/theme_toggle.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a theme toggle button to the navbar
- implement dark theme styles and JS toggle logic

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cee94d6c4832eae324604926a1ae1