### PR TITLE
Introduce advanced multiplier rules

### DIFF
--- a/pomodoro_app/main/api_routes.py
+++ b/pomodoro_app/main/api_routes.py
@@ -142,7 +142,7 @@ def api_start_timer():
             current_app.logger.error(f"API Start: Cannot find User {user_id} to start timer.")
             return jsonify({'error': 'User not found.'}), 500
 
-        current_multiplier = calculate_current_multiplier(user, work_minutes)
+        current_multiplier = calculate_current_multiplier(user, work_minutes, break_minutes)
         current_state = db.session.query(ActiveTimerState).filter_by(user_id=user_id).with_for_update().first()
 
         if current_state:
@@ -342,7 +342,7 @@ def api_complete_phase():
             # Instead of deleting, update the state for the next work session
             work_minutes = server_state.work_duration_minutes
             # Recalculate multiplier based on streaks *before* the work session starts
-            next_multiplier = calculate_current_multiplier(user, work_minutes)
+            next_multiplier = calculate_current_multiplier(user, work_minutes, server_state.break_duration_minutes)
             work_end_time_utc = now_utc + timedelta(minutes=work_minutes)
 
             server_state.phase = 'work'

--- a/pomodoro_app/main/logic.py
+++ b/pomodoro_app/main/logic.py
@@ -1,6 +1,8 @@
 # pomodoro_app/main/logic.py
-from datetime import timedelta, timezone, date
+from datetime import timedelta, timezone, date, datetime
 from flask import current_app
+from sqlalchemy import func
+from pomodoro_app import db
 from pomodoro_app.models import User, PomodoroSession, ActiveTimerState
 
 # --- Constants ---
@@ -12,10 +14,25 @@ MULTIPLIER_RULES = [
     {'id': 'consecutive5',  'condition': '5+ Consecutive Sessions', 'bonus': 0.2, 'details': 'Complete 5+ work/break cycles.'},
     {'id': 'daily3',        'condition': '3+ Day Usage Streak',     'bonus': 0.1, 'details': 'Use timer 3+ days running.'},
     {'id': 'daily7',        'condition': '7+ Day Usage Streak',     'bonus': 0.2, 'details': 'Use timer 7+ days running.'},
+    # --- New duration milestones ---
+    {'id': 'focus60',       'condition': 'Work Block > 60 Min',     'bonus': 0.3, 'details': 'Complete >60 mins in one work session.'},
+    {'id': 'focus90',       'condition': 'Work Block > 90 Min',     'bonus': 0.5, 'details': 'Complete >90 mins in one work session.'},
+    # --- Extended consistency ---
+    {'id': 'consecutive10', 'condition': '10+ Consecutive Sessions','bonus': 0.3, 'details': 'Complete 10+ work/break cycles.'},
+    {'id': 'consecutive20', 'condition': '20+ Consecutive Sessions','bonus': 0.5, 'details': 'Complete 20+ work/break cycles.'},
+    # --- Long-term daily streaks ---
+    {'id': 'daily14',       'condition': '14+ Day Usage Streak',    'bonus': 0.3, 'details': 'Use timer 14+ days running.'},
+    {'id': 'daily30',       'condition': '30+ Day Usage Streak',    'bonus': 0.5, 'details': 'Use timer 30+ days running.'},
+    # --- Daily focus total ---
+    {'id': 'dailyFocus120', 'condition': '120+ Min Focus Today',    'bonus': 0.1, 'details': 'Accumulate 120+ focus mins in one day.'},
+    # --- Balanced breaks ---
+    {'id': 'balancedBreak', 'condition': 'Breaks <=20% of Work',    'bonus': 0.1, 'details': 'Plan breaks under 20% of work time.'},
 ]
 MAX_CONSISTENCY_GAP_HOURS = 2
+BALANCED_BREAK_RATIO = 0.2
+DAILY_FOCUS_TARGET = 120
 
-def calculate_current_multiplier(user, work_duration_this_session=0):
+def calculate_current_multiplier(user, work_duration_this_session=0, break_duration_this_session=0):
     """
     Fully additive multiplier: bonuses stack.
     """
@@ -29,18 +46,47 @@ def calculate_current_multiplier(user, work_duration_this_session=0):
         total_bonus += 0.1
     if work_duration_this_session > 45:
         total_bonus += 0.2
+    if work_duration_this_session > 60:
+        total_bonus += 0.3
+    if work_duration_this_session > 90:
+        total_bonus += 0.5
+
+    # Balanced break bonus
+    if work_duration_this_session > 0 and break_duration_this_session > 0:
+        if break_duration_this_session / work_duration_this_session <= BALANCED_BREAK_RATIO:
+            total_bonus += 0.1
 
     # Consistency streak bonuses (additive)
     if user.consecutive_sessions >= 3:
         total_bonus += 0.1
     if user.consecutive_sessions >= 5:
         total_bonus += 0.2
+    if user.consecutive_sessions >= 10:
+        total_bonus += 0.3
+    if user.consecutive_sessions >= 20:
+        total_bonus += 0.5
 
     # Daily streak bonuses (additive)
     if user.daily_streak >= 3:
         total_bonus += 0.1
     if user.daily_streak >= 7:
         total_bonus += 0.2
+    if user.daily_streak >= 14:
+        total_bonus += 0.3
+    if user.daily_streak >= 30:
+        total_bonus += 0.5
+
+    # Daily focus total bonus
+    try:
+        today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        today_focus = db.session.query(func.coalesce(func.sum(PomodoroSession.work_duration), 0)).filter(
+            PomodoroSession.user_id == user.id,
+            PomodoroSession.timestamp >= today_start
+        ).scalar() or 0
+        if today_focus >= DAILY_FOCUS_TARGET:
+            total_bonus += 0.1
+    except Exception as e:
+        current_app.logger.error(f"Multiplier: Error calculating today's focus for user {user.id}: {e}")
 
     total_multiplier = 1.0 + total_bonus
     current_app.logger.debug(
@@ -48,7 +94,7 @@ def calculate_current_multiplier(user, work_duration_this_session=0):
     )
     return round(total_multiplier, 2)
 
-def get_active_multiplier_rules(user, work_duration_this_session=0):
+def get_active_multiplier_rules(user, work_duration_this_session=0, break_duration_this_session=0):
     """
     Return all rule IDs that currently apply (matches additive model).
     """
@@ -63,18 +109,45 @@ def get_active_multiplier_rules(user, work_duration_this_session=0):
         active_rule_ids.add('focus25')
     if work_duration_this_session > 45:
         active_rule_ids.add('focus45')
+    if work_duration_this_session > 60:
+        active_rule_ids.add('focus60')
+    if work_duration_this_session > 90:
+        active_rule_ids.add('focus90')
+
+    if work_duration_this_session > 0 and break_duration_this_session > 0:
+        if break_duration_this_session / work_duration_this_session <= BALANCED_BREAK_RATIO:
+            active_rule_ids.add('balancedBreak')
 
     # Consistency
     if user.consecutive_sessions >= 3:
         active_rule_ids.add('consecutive3')
     if user.consecutive_sessions >= 5:
         active_rule_ids.add('consecutive5')
+    if user.consecutive_sessions >= 10:
+        active_rule_ids.add('consecutive10')
+    if user.consecutive_sessions >= 20:
+        active_rule_ids.add('consecutive20')
 
     # Daily
     if user.daily_streak >= 3:
         active_rule_ids.add('daily3')
     if user.daily_streak >= 7:
         active_rule_ids.add('daily7')
+    if user.daily_streak >= 14:
+        active_rule_ids.add('daily14')
+    if user.daily_streak >= 30:
+        active_rule_ids.add('daily30')
+
+    try:
+        today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        today_focus = db.session.query(func.coalesce(func.sum(PomodoroSession.work_duration), 0)).filter(
+            PomodoroSession.user_id == user.id,
+            PomodoroSession.timestamp >= today_start
+        ).scalar() or 0
+        if today_focus >= DAILY_FOCUS_TARGET:
+            active_rule_ids.add('dailyFocus120')
+    except Exception as e:
+        current_app.logger.error(f"Active rules: Error calculating today's focus for user {user.id}: {e}")
 
     current_app.logger.debug(
         f"User {user.id}: active rules @ {work_duration_this_session}m → {active_rule_ids}"

--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -73,14 +73,16 @@ def timer():
              relevant_work_duration = active_state.work_duration_minutes
              current_app.logger.debug(f"Timer Route: Found active state for User {user_id}. Phase: {active_state.phase}. Multiplier: {active_multiplier}. Relevant duration for rules: {relevant_work_duration}")
         else:
-             # Calculate potential multiplier for *next* session using the helper
-             # Use 0 duration for potential calculation to avoid showing duration bonus before start
-             relevant_work_duration = 0
-             active_multiplier = calculate_current_multiplier(user, relevant_work_duration)
-             current_app.logger.debug(f"Timer Route: No active state for User {user_id}. Potential next multiplier: {active_multiplier}. Relevant duration for rules: {relevant_work_duration}")
+            # Calculate potential multiplier for *next* session using the helper
+            # Use 0 duration for potential calculation to avoid showing duration bonus before start
+            relevant_work_duration = 0
+            active_multiplier = calculate_current_multiplier(user, relevant_work_duration, 0)
+            current_app.logger.debug(
+                f"Timer Route: No active state for User {user_id}. Potential next multiplier: {active_multiplier}. Relevant duration for rules: {relevant_work_duration}"
+            )
 
         # Call the function to get the set of active rule IDs based on current user state and the relevant duration
-        active_rule_ids = get_active_multiplier_rules(user, relevant_work_duration)
+        active_rule_ids = get_active_multiplier_rules(user, relevant_work_duration, getattr(active_state, 'break_duration_minutes', 0))
 
     except SQLAlchemyError as e:
         current_app.logger.error(f"Timer Route: Database error loading data for User {user_id}: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- add longer focus, extended streaks, and balanced break rules
- compute daily total focus bonus
- adjust multiplier calculations and rule listings

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cee55a7bc832eba020fdf2877baf4