### PR TITLE
Improve dark theme colors

### DIFF
--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -757,7 +757,7 @@ body.dark-theme input::placeholder,
 body.dark-theme textarea::placeholder {
   color: #bbb;
 }
-body.dark-theme .sessions-table thead th { color: #ddd; }
+body.dark-theme .sessions-table thead th { color: #000; }
 body.dark-theme .sessions-table th,
 body.dark-theme .sessions-table td {
   border-color: #444;
@@ -794,3 +794,13 @@ body.dark-theme .flash.info {
 body.dark-theme .form-group label { color: #ccc; }
 body.dark-theme .stats li strong { color: #ddd; }
 body.dark-theme .timer-display { color: #e9e9e9; }
+body.dark-theme .timer-main-title {
+  background: linear-gradient(90deg, #2a2a2a 60%, #3a3a3a 100%);
+  color: #eee;
+}
+body.dark-theme .multiplier-rules-container h3 { color: #ddd; }
+body.dark-theme .multiplier-rules-table td:nth-child(3) { color: #ddd; }
+body.dark-theme .dashboard-main-title {
+  background: linear-gradient(90deg, #2a2a2a 60%, #3a3a3a 100%);
+  color: #eee;
+}


### PR DESCRIPTION
## Summary
- tweak dark theme colors for timer, multiplier rules, dashboard and session table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pomodoro_app')*

------
https://chatgpt.com/codex/tasks/task_e_686d09af0d1c832eb5786eabb1fd52a9