### PR TITLE
Add leaderboard feature

### DIFF
--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -206,3 +206,14 @@ def dashboard():
                            week_sessions=week_sessions,
                            sessions=aware_sessions, # Pass the potentially timezone-aware sessions
                            chat_enabled=chat_enabled)
+
+
+@main.route('/leaderboard')
+def leaderboard():
+    """Display leaderboard of users ordered by points."""
+    try:
+        users = db.session.query(User).order_by(User.total_points.desc()).limit(10).all()
+    except SQLAlchemyError as e:
+        current_app.logger.error(f"Leaderboard: DB error: {e}", exc_info=True)
+        users = []
+    return render_template('main/leaderboard.html', users=users)

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -20,8 +20,10 @@
         {% if current_user.is_authenticated %}
           <a href="{{ url_for('main.timer') }}">Timer</a>
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
+          <a href="{{ url_for('main.leaderboard') }}">Leaderboard</a>
           <a href="{{ url_for('auth.logout') }}">Logout</a>
         {% else %}
+          <a href="{{ url_for('main.leaderboard') }}">Leaderboard</a>
           <a href="{{ url_for('auth.login') }}">Login</a>
           <a href="{{ url_for('auth.register') }}">Register</a>
         {% endif %}

--- a/pomodoro_app/templates/main/leaderboard.html
+++ b/pomodoro_app/templates/main/leaderboard.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2 class="leaderboard-title">Leaderboard</h2>
+  <table class="leaderboard-table">
+    <thead>
+      <tr><th>Rank</th><th>Name</th><th>Points</th></tr>
+    </thead>
+    <tbody>
+    {% for user in users %}
+      <tr>
+        <td>{{ loop.index }}</td>
+        <td>{{ user.name }}</td>
+        <td>{{ user.total_points }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,3 +103,18 @@ def test_complete_session_requires_login(test_client, init_database):
     # Since login_view is set, it should redirect
     assert response.status_code == 302 # Redirect status
     assert 'login' in response.location # Check redirect location
+
+
+def test_leaderboard_page(test_client, init_database, test_app):
+    from werkzeug.security import generate_password_hash
+    with test_app.app_context():
+        from pomodoro_app.models import User
+        user1 = User(name='Alice', email='alice@example.com', password=generate_password_hash('a'), total_points=100)
+        user2 = User(name='Bob', email='bob@example.com', password=generate_password_hash('b'), total_points=50)
+        db.session.add_all([user1, user2])
+        db.session.commit()
+
+    response = test_client.get(url_for('main.leaderboard'))
+    assert response.status_code == 200
+    assert b'Leaderboard' in response.data
+    assert b'Alice' in response.data


### PR DESCRIPTION
## Summary
- add `/leaderboard` route with template
- show leaderboard link in navigation
- test new page loads and displays users

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d141ad608832e99f1aacb7440dd33