### PR TITLE
Improve leaderboard styling

### DIFF
--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -555,7 +555,77 @@ body.dark-theme {
   background: #f8f9fa;
 }
 .sessions-table tr:hover {
-    background-color: #f1f1f1;
+  background-color: #f1f1f1;
+}
+
+/* Leaderboard Styles */
+.leaderboard-title {
+  display: block;
+  text-align: center;
+  font-size: 2.2em;
+  font-weight: 700;
+  margin: 0.5em auto 1em auto;
+  padding: 0.4em 1.2em;
+  background: linear-gradient(90deg, #f8fafc 60%, #e3e8ef 100%);
+  border-radius: 1em;
+  box-shadow: 0 2px 8px rgba(52,58,64,0.07);
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 2em;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+}
+
+.leaderboard-table th,
+.leaderboard-table td {
+  padding: 0.8em 1em;
+  border-bottom: 1px solid #dee2e6;
+  text-align: left;
+}
+.leaderboard-table th:first-child,
+.leaderboard-table td:first-child {
+  text-align: center;
+}
+
+.leaderboard-table thead th {
+  background-color: #e9ecef;
+  font-weight: 600;
+  color: #495057;
+}
+
+.leaderboard-table tbody tr:nth-child(even) {
+  background-color: #f8f9fa;
+}
+
+.leaderboard-table tbody tr:hover {
+  background-color: #f1f5fa;
+}
+
+.leaderboard-table tbody tr:first-child {
+  background-color: #fff8e1;
+  font-weight: 700;
+}
+
+.leaderboard-table tbody tr:nth-child(2) {
+  background-color: #f4f4f4;
+  font-weight: 600;
+}
+
+.leaderboard-table tbody tr:nth-child(3) {
+  background-color: #ffefd5;
+  font-weight: 600;
+}
+
+.leaderboard-table tbody tr:first-child td:first-child::before {
+  content: "\1F947\0020"; /* gold medal emoji + space */
+}
+.leaderboard-table tbody tr:nth-child(2) td:first-child::before {
+  content: "\1F948\0020"; /* silver medal emoji + space */
+}
+.leaderboard-table tbody tr:nth-child(3) td:first-child::before {
+  content: "\1F949\0020"; /* bronze medal emoji + space */
 }
 
 
@@ -803,4 +873,34 @@ body.dark-theme .multiplier-rules-table td:nth-child(3) { color: #ddd; }
 body.dark-theme .dashboard-main-title {
   background: linear-gradient(90deg, #2a2a2a 60%, #3a3a3a 100%);
   color: #eee;
+}
+
+body.dark-theme .leaderboard-title {
+  background: linear-gradient(90deg, #2a2a2a 60%, #3a3a3a 100%);
+  color: #eee;
+}
+
+body.dark-theme .leaderboard-table thead th {
+  background-color: #2c2c2c;
+  color: #eee;
+}
+
+body.dark-theme .leaderboard-table tbody tr:nth-child(even) {
+  background-color: #1a1a1a;
+}
+
+body.dark-theme .leaderboard-table tbody tr:hover {
+  background-color: #333;
+}
+
+body.dark-theme .leaderboard-table tbody tr:first-child {
+  background-color: #665c2c;
+}
+
+body.dark-theme .leaderboard-table tbody tr:nth-child(2) {
+  background-color: #454545;
+}
+
+body.dark-theme .leaderboard-table tbody tr:nth-child(3) {
+  background-color: #665040;
 }


### PR DESCRIPTION
## Summary
- add modern leaderboard table styling with medal indicators
- support dark theme for the new styles

## Testing
- `pip install -r requirements.txt`
- `export PYTHONPATH=$PWD`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d24552c2c832ea4a00b63150c848a