### PR TITLE
Implement chat history storage

### DIFF
--- a/migrations/versions/001_add_chat_message_table.py
+++ b/migrations/versions/001_add_chat_message_table.py
@@ -1,0 +1,25 @@
+"""add chat message table"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'chat_messages',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('role', sa.String(length=20), nullable=False),
+        sa.Column('text', sa.Text(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE')
+    )
+    op.create_index('ix_chat_messages_user_id_timestamp', 'chat_messages', ['user_id', 'timestamp'])
+
+
+def downgrade():
+    op.drop_index('ix_chat_messages_user_id_timestamp', table_name='chat_messages')
+    op.drop_table('chat_messages')

--- a/pomodoro_app/static/js/agent_chat.js
+++ b/pomodoro_app/static/js/agent_chat.js
@@ -150,7 +150,8 @@ async function sendAgentMessage() {
                 prompt: message,
                 dashboard_data: dashboardData,
                 agent_type: agentType,
-                tts_enabled: isTtsEnabledByUser
+                tts_enabled: isTtsEnabledByUser,
+                message_count: chatHistory.length
             })
         });
         const data = await response.json();


### PR DESCRIPTION
## Summary
- add `ChatMessage` model and migration
- persist chat messages and include recent history when calling OpenAI
- send message count from the chat UI
- test chat history persistence

## Testing
- `pip install -e .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9eb33858832eaf69fad84574911a