### PR TITLE
Fix syntax in ActiveTimerState __repr__

### DIFF
--- a/pomodoro_app/models.py
+++ b/pomodoro_app/models.py
@@ -64,7 +64,12 @@ class ActiveTimerState(db.Model):
     # Decided against the backref on User for simplicity, can query by user_id easily.
 
     def __repr__(self):
-        end_repr = self.end_time.isoformat() if self.end_time else "None"        return f'<ActiveTimerState user_id={self.user_id} phase={self.phase} mult={self.current_multiplier} ends={end_repr}>'
+        end_repr = self.end_time.isoformat() if self.end_time else "None"
+        return (
+            f"<ActiveTimerState user_id={self.user_id} "
+            f"phase={self.phase} mult={self.current_multiplier} "
+            f"ends={end_repr}>"
+        )
 
 
 # +++ Chat Message History Model +++


### PR DESCRIPTION
## Summary
- fix bad line break in ActiveTimerState __repr__

## Testing
- `pip install -e .`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da209e3e0832eaeb389b15438449d