### PR TITLE
Clear chat session data on auth pages

### DIFF
--- a/pomodoro_app/templates/auth/login.html
+++ b/pomodoro_app/templates/auth/login.html
@@ -19,4 +19,8 @@
     {{ form.submit(class="btn") }}
   </form>
   <p>New user? <a href="{{ url_for('auth.register') }}">Register an account.</a></p>
+  <script>
+    sessionStorage.removeItem('pomodoroAgentChatHistory_v1');
+    sessionStorage.removeItem('pomodoroAgentSelected_v1');
+  </script>
 {% endblock %}

--- a/pomodoro_app/templates/auth/register.html
+++ b/pomodoro_app/templates/auth/register.html
@@ -26,4 +26,8 @@
     {{ form.submit(class="btn") }}
   </form>
   <p>Already have an account? <a href="{{ url_for('auth.login') }}">Log in here.</a></p>
+  <script>
+    sessionStorage.removeItem('pomodoroAgentChatHistory_v1');
+    sessionStorage.removeItem('pomodoroAgentSelected_v1');
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a small script to `login.html` and `register.html` to clear
  `pomodoroAgentChatHistory_v1` and `pomodoroAgentSelected_v1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dab1614dc832eb7f30a4716164626