### PR TITLE
Fix: clear chat data on logout

### DIFF
--- a/pomodoro_app/static/js/theme_toggle.js
+++ b/pomodoro_app/static/js/theme_toggle.js
@@ -22,4 +22,12 @@
     applyTheme(newTheme);
     localStorage.setItem('theme', newTheme);
   });
+
+  const logoutLink = document.getElementById('logout-link');
+  if (logoutLink) {
+    logoutLink.addEventListener('click', () => {
+      sessionStorage.removeItem('pomodoroAgentChatHistory_v1');
+      sessionStorage.removeItem('pomodoroAgentSelected_v1');
+    });
+  }
 })();

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -22,7 +22,7 @@
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
           <a href="{{ url_for('main.my_data') }}">My Data</a>
           <a href="{{ url_for('main.leaderboard') }}">Leaderboard</a>
-          <a href="{{ url_for('auth.logout') }}">Logout</a>
+          <a id="logout-link" href="{{ url_for('auth.logout') }}">Logout</a>
         {% else %}
           <a href="{{ url_for('main.leaderboard') }}">Leaderboard</a>
           <a href="{{ url_for('auth.login') }}">Login</a>


### PR DESCRIPTION
## Summary
- add `logout-link` id to logout link in `base.html`
- clear chat session data on logout via `theme_toggle.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db336e0d4832e8e4fde87e9059b46