### PR TITLE
Fix CSRF for message delete

### DIFF
--- a/pomodoro_app/templates/main/my_data.html
+++ b/pomodoro_app/templates/main/my_data.html
@@ -10,7 +10,8 @@
             <strong>{{ msg.role.title() }}</strong>
             <em>{{ msg.timestamp.isoformat() if msg.timestamp else '' }}</em>
             <form action="{{ url_for('main.delete_message', message_id=msg.id) }}" method="post" style="display:inline; margin-left:1em;">
-              <button type="submit" class="btn btn-sm">Delete</button>
+                {{ csrf_token() }}
+                <button type="submit" class="btn btn-sm">Delete</button>
             </form>
           </div>
           <div class="chat-text">{{ msg.text }}</div>


### PR DESCRIPTION
## Summary
- include CSRF token in delete forms on the My Data page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686db33770d8832ea0a940b1d63a27a3