### PR TITLE
Reduce theme toggle prominence

### DIFF
--- a/pomodoro_app/static/js/theme_toggle.js
+++ b/pomodoro_app/static/js/theme_toggle.js
@@ -6,10 +6,10 @@
   function applyTheme(theme) {
     if (theme === 'dark') {
       document.body.classList.add('dark-theme');
-      toggleBtn.textContent = 'Light Mode';
+      toggleBtn.textContent = '☀️';
     } else {
       document.body.classList.remove('dark-theme');
-      toggleBtn.textContent = 'Dark Mode';
+      toggleBtn.textContent = '🌙';
     }
   }
 

--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -174,6 +174,8 @@ body.dark-theme {
 }
 .navbar .nav-links a {
   color: #dee2e6; /* Lighter gray for links */
+  font-weight: 600;
+  font-size: 1.1em;
   transition: color 0.2s ease;
 }
 .navbar .nav-links a:hover {
@@ -182,6 +184,16 @@ body.dark-theme {
 }
 .theme-toggle {
   margin-left: 1em;
+  background: transparent;
+  border: none;
+  color: #ccc;
+  font-size: 1.1em;
+  padding: 0.2em 0.4em;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+.theme-toggle:hover {
+  color: #fff;
 }
 
 /* Container */

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -29,7 +29,7 @@
           <a href="{{ url_for('auth.register') }}">Register</a>
         {% endif %}
       </div>
-      <button id="theme-toggle" class="theme-toggle btn btn-sm">Dark Mode</button>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">🌙</button>
     </div>
   </nav>
 


### PR DESCRIPTION
## Summary
- minimize theme toggle button styling and use icons
- emphasize navigation links for Timer and Dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dbe792e1c832ead37be9d83e865e5