### PR TITLE
Fix missing cookies in chat API calls

### DIFF
--- a/pomodoro_app/static/js/agent_chat.js
+++ b/pomodoro_app/static/js/agent_chat.js
@@ -146,6 +146,7 @@ async function sendAgentMessage() {
         const response = await fetch('/api/chat', {
             method: 'POST',
             headers: headers,
+            credentials: 'same-origin',
             body: JSON.stringify({
                 prompt: message,
                 dashboard_data: dashboardData,


### PR DESCRIPTION
## Summary
- ensure fetch requests for the chat API include cookies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dbe2ae418832eabfb3f1a6d34e677