### PR TITLE
Implement pair deletion for chat logs

### DIFF
--- a/pomodoro_app/templates/main/my_data.html
+++ b/pomodoro_app/templates/main/my_data.html
@@ -20,6 +20,15 @@
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit" class="btn btn-sm btn-danger">Delete</button>
             </form>
+            {% if msg.role == 'user' %}
+            <form action="{{ url_for('main.delete_message_pair', message_id=msg.id) }}"
+                  method="post"
+                  style="display:inline;margin-left:0.5em;"
+                  onsubmit="return confirm('Delete this message and its pair?');">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button type="submit" class="btn btn-sm btn-warning">Delete Pair</button>
+            </form>
+            {% endif %}
           </div>
 
           <div class="chat-text">{{ msg.text }}</div>


### PR DESCRIPTION
## Summary
- add `delete_message_pair` route to remove user/assistant message pairs
- add "Delete Pair" button in chat history template
- test new pair deletion functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ce8ebd40832e8193b16a7ec9071b