### PR TITLE
Remove single chat message deletion

### DIFF
--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -247,26 +247,6 @@ def my_data():
     return render_template('main/my_data.html', messages=messages)
 
 
-@main.route('/mydata/delete/<int:message_id>', methods=['POST'])
-@login_required
-def delete_message(message_id):
-    """Delete a single chat message that belongs to the current user."""
-    msg = ChatMessage.query.get_or_404(message_id)
-
-    if msg.user_id != current_user.id:                # extra safety
-        abort(403)
-
-    try:
-        db.session.delete(msg)
-        db.session.commit()
-        flash('Message deleted.', 'success')
-    except SQLAlchemyError as e:
-        db.session.rollback()
-        current_app.logger.error(f"MyData: DB error deleting msg {message_id}: {e}")
-        flash('Database error; message not deleted.', 'error')
-
-    return redirect(url_for('main.my_data'))
-
 
 @main.route('/mydata/delete_pair/<int:message_id>', methods=['POST'])
 @login_required

--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -959,3 +959,28 @@ body.dark-theme .leaderboard-table tbody tr:nth-child(2) {
 body.dark-theme .leaderboard-table tbody tr:nth-child(3) {
   background-color: #665040;
 }
+
+/* Chat history pair styling */
+.chat-history-item.user-message {
+  background: #eef6fc;
+  border: 1px solid #cbd5e0;
+  border-radius: 0.5em 0.5em 0 0;
+  padding: 0.5em 1em;
+  margin-top: 1em;
+}
+.chat-history-item.assistant-message {
+  background: #f8f9fa;
+  border: 1px solid #cbd5e0;
+  border-top: 0;
+  border-radius: 0 0 0.5em 0.5em;
+  padding: 0.5em 1em;
+  margin-bottom: 1em;
+}
+body.dark-theme .chat-history-item.user-message {
+  background: #1c1f27;
+  border-color: #343a40;
+}
+body.dark-theme .chat-history-item.assistant-message {
+  background: #222;
+  border-color: #343a40;
+}

--- a/pomodoro_app/templates/main/my_data.html
+++ b/pomodoro_app/templates/main/my_data.html
@@ -1,25 +1,16 @@
 {% extends "base.html" %}
 {% block content %}
   <h2 class="dashboard-main-title">My Data</h2>
-  <p>Below is your stored chat history. You can delete individual messages.</p>
+  <p>Below is your stored chat history. Messages are grouped in user/assistant pairs. Use the button on a user message to delete its pair.</p>
 
   {% if messages %}
     <ul class="chat-history">
       {% for msg in messages %}
-        <li class="chat-history-item">
+        <li class="chat-history-item {{ 'user-message' if msg.role == 'user' else 'assistant-message' }}">
           <div>
             <strong>{{ msg.role.title() }}</strong>
             <em>{{ msg.timestamp.isoformat() if msg.timestamp else '' }}</em>
 
-            {# ONE form, ONE token, ONE button #}
-            <form action="{{ url_for('main.delete_message', message_id=msg.id) }}"
-                  method="post"
-                  style="display:inline;margin-left:1em;"
-                  onsubmit="return confirm('Delete this message?');">
-              <!-- hidden CSRF field so Flask-WTF receives it -->
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button type="submit" class="btn btn-sm btn-danger">Delete</button>
-            </form>
             {% if msg.role == 'user' %}
             <form action="{{ url_for('main.delete_message_pair', message_id=msg.id) }}"
                   method="post"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -179,7 +179,7 @@ def test_mydata_requires_login(test_client, init_database):
     assert b'Login' in resp.data
 
 
-def test_mydata_view_and_delete(logged_in_user, clean_db, test_app):
+def test_mydata_view_has_pair_delete_only(logged_in_user, clean_db, test_app):
     from pomodoro_app.models import ChatMessage, User
 
     with test_app.app_context():
@@ -188,18 +188,12 @@ def test_mydata_view_and_delete(logged_in_user, clean_db, test_app):
         msg2 = ChatMessage(user_id=user.id, role='assistant', text='hi')
         db.session.add_all([msg1, msg2])
         db.session.commit()
-        msg1_id = msg1.id
 
     resp = logged_in_user.get(url_for('main.my_data'))
     assert resp.status_code == 200
     assert b'hello' in resp.data
-
-    resp = logged_in_user.post(url_for('main.delete_message', message_id=msg1_id), follow_redirects=True)
-    assert resp.status_code == 200
-    assert b'Message deleted' in resp.data
-
-    with test_app.app_context():
-        assert ChatMessage.query.get(msg1_id) is None
+    assert b'Delete Pair' in resp.data
+    assert b'btn-danger' not in resp.data
 
 
 def test_mydata_delete_pair(logged_in_user, clean_db, test_app):


### PR DESCRIPTION
## Summary
- remove `/mydata/delete/<id>` route
- update My Data page to only allow deleting message pairs
- add styles to visually group user/assistant message pairs
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713f8be0a4832e8eb8a9e76da7ca3e