### PR TITLE
Fix chat history spacing

### DIFF
--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -966,7 +966,7 @@ body.dark-theme .leaderboard-table tbody tr:nth-child(3) {
   border: 1px solid #cbd5e0;
   border-radius: 0.5em 0.5em 0 0;
   padding: 0.5em 1em;
-  margin-top: 1em;
+  margin-top: 0;
 }
 .chat-history-item.assistant-message {
   background: #f8f9fa;


### PR DESCRIPTION
## Summary
- fix vertical spacing within user/assistant message pairs in My Data page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874dda1be4c832e82407ead1f22ad44