### PR TITLE
Add user settings for productivity preferences

### DIFF
--- a/pomodoro_app/forms.py
+++ b/pomodoro_app/forms.py
@@ -1,7 +1,7 @@
 # pomodoro_app/forms.py
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, BooleanField, SubmitField
-from wtforms.validators import DataRequired, Email, EqualTo, Length
+from wtforms import StringField, PasswordField, BooleanField, SubmitField, IntegerField
+from wtforms.validators import DataRequired, Email, EqualTo, Length, NumberRange
 
 class RegistrationForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired(), Length(min=2, max=100)])
@@ -15,3 +15,15 @@ class LoginForm(FlaskForm):
     password = PasswordField('Password', validators=[DataRequired()])
     remember = BooleanField('Remember Me')
     submit = SubmitField('Log In')
+
+
+class SettingsForm(FlaskForm):
+    preferred_work_minutes = IntegerField(
+        'Preferred Work Minutes',
+        validators=[DataRequired(), NumberRange(min=1, max=600)]
+    )
+    productivity_goal = StringField(
+        'Productivity Goal',
+        validators=[Length(max=200)]
+    )
+    submit = SubmitField('Save Settings')

--- a/pomodoro_app/main/api_routes.py
+++ b/pomodoro_app/main/api_routes.py
@@ -594,6 +594,8 @@ The user '{user.name}' (ID: {user.id}) is asking a question. Their current stats
 - Total Points: {user_points}
 - Total Focus Time (all time, minutes): {total_focus_db}
 - Total Pomodoro Sessions Completed (all time): {total_sessions_db}
+- Preferred Work Length: {user.preferred_work_minutes} minutes
+- Productivity Goal: {user.productivity_goal or 'None set'}
 Please answer based solely on these stats and general knowledge about the Pomodoro technique.
 Keep your response positive, concise (1–4 sentences), and use Markdown formatting.
 If the question is unrelated to productivity, politely decline.

--- a/pomodoro_app/models.py
+++ b/pomodoro_app/models.py
@@ -18,6 +18,15 @@ class User(UserMixin, db.Model):
     daily_streak = db.Column(db.Integer, nullable=False, default=0, server_default='0')
     last_active_date = db.Column(db.Date, nullable=True) # Track last active date for daily streak
 
+    # --- User Preferences ---
+    preferred_work_minutes = db.Column(
+        db.Integer,
+        nullable=False,
+        default=25,
+        server_default='25'
+    )
+    productivity_goal = db.Column(db.String(200), nullable=True)
+
     # Relationship backrefs defined below (for PomodoroSession)
     # sessions backref defined in PomodoroSession model
 

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -20,6 +20,7 @@
         {% if current_user.is_authenticated %}
           <a href="{{ url_for('main.timer') }}">Timer</a>
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
+          <a href="{{ url_for('main.settings') }}">Settings</a>
           <a href="{{ url_for('main.my_data') }}">My Data</a>
           <a href="{{ url_for('main.leaderboard') }}">Leaderboard</a>
           <a id="logout-link" href="{{ url_for('auth.logout') }}">Logout</a>

--- a/pomodoro_app/templates/main/settings.html
+++ b/pomodoro_app/templates/main/settings.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>User Settings</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.preferred_work_minutes.label }}<br>
+      {{ form.preferred_work_minutes(class="input") }}
+      {% for error in form.preferred_work_minutes.errors %}<span class="error">{{ error }}</span>{% endfor %}
+    </div>
+    <div class="form-group">
+      {{ form.productivity_goal.label }}<br>
+      {{ form.productivity_goal(class="input") }}
+      {% for error in form.productivity_goal.errors %}<span class="error">{{ error }}</span>{% endfor %}
+    </div>
+    {{ form.submit(class="btn") }}
+  </form>
+{% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -268,3 +268,23 @@ def test_mydata_limit(logged_in_user, clean_db, test_app, monkeypatch):
         from pomodoro_app.models import ChatMessage, User
         user = User.query.filter_by(email='test@example.com').first()
         assert ChatMessage.query.filter_by(user_id=user.id).count() == 15
+
+
+def test_settings_page_requires_login(test_client, init_database):
+    resp = test_client.get(url_for('main.settings'), follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Login' in resp.data
+
+
+def test_update_settings(logged_in_user, test_app):
+    resp = logged_in_user.post(url_for('main.settings'), data={
+        'preferred_work_minutes': '30',
+        'productivity_goal': 'Write more code',
+        'submit': True
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    with test_app.app_context():
+        from pomodoro_app.models import User
+        user = User.query.filter_by(email='test@example.com').first()
+        assert user.preferred_work_minutes == 30
+        assert user.productivity_goal == 'Write more code'


### PR DESCRIPTION
## Summary
- extend `User` model with preferences
- add `SettingsForm` and settings page
- integrate preferences in chat context
- provide nav link to Settings
- test settings page and update functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ddcfb4b8832ea171a9256c09bd47