### PR TITLE
Fix my data message order

### DIFF
--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -238,7 +238,7 @@ def my_data():
     try:
         messages = (ChatMessage.query
                                .filter_by(user_id=current_user.id)
-                               .order_by(ChatMessage.timestamp.desc())
+                               .order_by(ChatMessage.timestamp.asc())
                                .all())
     except SQLAlchemyError as e:
         current_app.logger.error(f"MyData: DB error for user {current_user.id}: {e}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -196,6 +196,23 @@ def test_mydata_view_has_pair_delete_only(logged_in_user, clean_db, test_app):
     assert b'btn-danger' not in resp.data
 
 
+def test_mydata_messages_order(logged_in_user, clean_db, test_app):
+    """Messages should be displayed with the user message above its assistant response."""
+    from pomodoro_app.models import ChatMessage, User
+
+    with test_app.app_context():
+        user = User.query.filter_by(email='test@example.com').first()
+        m1 = ChatMessage(user_id=user.id, role='user', text='first question')
+        m2 = ChatMessage(user_id=user.id, role='assistant', text='first answer')
+        db.session.add_all([m1, m2])
+        db.session.commit()
+
+    resp = logged_in_user.get(url_for('main.my_data'))
+    assert resp.status_code == 200
+    page = resp.get_data(as_text=True)
+    assert page.index('first question') < page.index('first answer')
+
+
 def test_mydata_delete_pair(logged_in_user, clean_db, test_app):
     from pomodoro_app.models import ChatMessage, User
 


### PR DESCRIPTION
## Summary
- show chat history in chronological order so user message is above assistant message
- test that my data page lists user message then response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e29d24f0832ea797a36349bcc986