### PR TITLE
Add global countdown widget

### DIFF
--- a/pomodoro_app/static/js/global_timer.js
+++ b/pomodoro_app/static/js/global_timer.js
@@ -1,0 +1,86 @@
+(function(){
+  'use strict';
+  const display = document.getElementById('global-timer-display');
+  if(!display) return;
+  // if full timer page is loaded, skip to avoid duplicate logic
+  if(document.getElementById('timer-component')) return;
+
+  const apiUrls = window.pomodoroApiUrls || {};
+  const csrfMeta = document.querySelector('meta[name=csrf-token]');
+  const csrf = csrfMeta ? csrfMeta.content : null;
+
+  let phase = 'idle';
+  let endTimeMs = null;
+  let intervalId = null;
+
+  function formatTime(sec){
+    const m = Math.floor(sec/60).toString().padStart(2,'0');
+    const s = Math.floor(sec%60).toString().padStart(2,'0');
+    return `${m}:${s}`;
+  }
+
+  async function fetchState(){
+    try{
+      const resp = await fetch(apiUrls.getState, {credentials:'same-origin'});
+      const data = await resp.json();
+      if(resp.ok && data.active){
+        phase = data.phase;
+        endTimeMs = new Date(data.end_time).getTime();
+        startTicker();
+      } else {
+        display.textContent = '';
+      }
+    }catch(e){
+      console.error('Global timer state error', e);
+    }
+  }
+
+  function startTicker(){
+    update();
+    clearInterval(intervalId);
+    intervalId = setInterval(update, 1000);
+  }
+
+  async function handleCompletion(){
+    if(!csrf) return;
+    try{
+      const resp = await fetch(apiUrls.complete, {
+        method:'POST',
+        headers:{'Content-Type':'application/json','X-CSRFToken':csrf},
+        credentials:'same-origin',
+        body: JSON.stringify({phase_completed: phase})
+      });
+      const data = await resp.json();
+      if(resp.ok){
+        if(data.status === 'break_started' || data.status === 'work_started'){
+          phase = data.status === 'break_started' ? 'break' : 'work';
+          endTimeMs = new Date(data.end_time).getTime();
+          startTicker();
+          return;
+        }
+      }
+      phase = 'idle';
+      display.textContent = '';
+    }catch(e){
+      console.error('Global timer completion error', e);
+    }
+  }
+
+  function update(){
+    if(endTimeMs==null){ display.textContent=''; return; }
+    const remaining = Math.max(0, Math.floor((endTimeMs - Date.now())/1000));
+    display.textContent = formatTime(remaining);
+    if(remaining<=0){
+      clearInterval(intervalId);
+      handleCompletion();
+    }
+  }
+
+  document.addEventListener('visibilitychange', function(){
+    if(!document.hidden && phase!=='idle'){
+      fetchState();
+    }
+  });
+
+  fetchState();
+})();

--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -196,6 +196,14 @@ body.dark-theme {
   color: #fff;
 }
 
+/* Small timer display in navbar */
+.nav-timer {
+  color: #ffec99;
+  font-weight: 600;
+  margin-left: auto;
+  margin-right: 1em;
+}
+
 /* Container */
 .container {
   max-width: 960px;

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -30,7 +30,8 @@
           <a href="{{ url_for('auth.register') }}">Register</a>
         {% endif %}
       </div>
-        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">🌙</button>
+      <span id="global-timer-display" class="nav-timer"></span>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">🌙</button>
     </div>
   </nav>
 
@@ -59,6 +60,16 @@
     {% endwith %}
     {% block content %}{% endblock %}
   </div>
+  <script>
+    window.pomodoroApiUrls = {
+      start: "{{ url_for('main.api_start_timer') }}",
+      complete: "{{ url_for('main.api_complete_phase') }}",
+      getState: "{{ url_for('main.api_get_timer_state') }}",
+      reset: "{{ url_for('main.api_reset_timer') }}",
+      resume: "{{ url_for('main.api_resume_timer') }}"
+    };
+  </script>
+  <script src="{{ url_for('static', filename='js/global_timer.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/theme_toggle.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a compact timer in the navbar
- expose timer API URLs globally
- run new `global_timer.js` on all pages to keep countdown active
- style `nav-timer` element

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874de38a570832eafd81f4deec1edab