### PR TITLE
Enhance AI profile settings

### DIFF
--- a/pomodoro_app/forms.py
+++ b/pomodoro_app/forms.py
@@ -1,7 +1,7 @@
 # pomodoro_app/forms.py
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, BooleanField, SubmitField, IntegerField
-from wtforms.validators import DataRequired, Email, EqualTo, Length, NumberRange
+from wtforms.validators import DataRequired, Email, EqualTo, Length, NumberRange, Optional
 
 class RegistrationForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired(), Length(min=2, max=100)])
@@ -25,5 +25,13 @@ class SettingsForm(FlaskForm):
     productivity_goal = StringField(
         'Productivity Goal',
         validators=[Length(max=200)]
+    )
+    daily_focus_goal = IntegerField(
+        'Daily Focus Goal (minutes)',
+        validators=[Optional(), NumberRange(min=1, max=1440)]
+    )
+    focus_description = StringField(
+        'Focus Description',
+        validators=[Optional(), Length(max=200)]
     )
     submit = SubmitField('Save Settings')

--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -287,11 +287,13 @@ def delete_message_pair(message_id):
 @main.route('/settings', methods=['GET', 'POST'])
 @login_required
 def settings():
-    """Allow users to update personal productivity preferences."""
+    """Edit AI profile and productivity preferences."""
     form = SettingsForm(obj=current_user)
     if form.validate_on_submit():
         current_user.preferred_work_minutes = form.preferred_work_minutes.data
         current_user.productivity_goal = form.productivity_goal.data
+        current_user.daily_focus_goal = form.daily_focus_goal.data
+        current_user.focus_description = form.focus_description.data
         try:
             db.session.commit()
             flash('Settings updated.', 'success')

--- a/pomodoro_app/models.py
+++ b/pomodoro_app/models.py
@@ -26,6 +26,8 @@ class User(UserMixin, db.Model):
         server_default='25'
     )
     productivity_goal = db.Column(db.String(200), nullable=True)
+    daily_focus_goal = db.Column(db.Integer, nullable=True)
+    focus_description = db.Column(db.String(200), nullable=True)
 
     # Relationship backrefs defined below (for PomodoroSession)
     # sessions backref defined in PomodoroSession model

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -20,7 +20,7 @@
         {% if current_user.is_authenticated %}
           <a href="{{ url_for('main.timer') }}">Timer</a>
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
-          <a href="{{ url_for('main.settings') }}">Settings</a>
+          <a href="{{ url_for('main.settings') }}">AI Profile</a>
           <a href="{{ url_for('main.my_data') }}">My Data</a>
           <a href="{{ url_for('main.leaderboard') }}">Leaderboard</a>
           <a id="logout-link" href="{{ url_for('auth.logout') }}">Logout</a>

--- a/pomodoro_app/templates/main/settings.html
+++ b/pomodoro_app/templates/main/settings.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block content %}
-  <h2>User Settings</h2>
+  <h2>AI Profile</h2>
+  <p class="form-explainer">
+    The details below help the AI assistant understand your goals and
+    personalize its guidance.
+  </p>
   <form method="POST">
     {{ form.hidden_tag() }}
     <div class="form-group">
@@ -12,6 +16,16 @@
       {{ form.productivity_goal.label }}<br>
       {{ form.productivity_goal(class="input") }}
       {% for error in form.productivity_goal.errors %}<span class="error">{{ error }}</span>{% endfor %}
+    </div>
+    <div class="form-group">
+      {{ form.daily_focus_goal.label }}<br>
+      {{ form.daily_focus_goal(class="input") }}
+      {% for error in form.daily_focus_goal.errors %}<span class="error">{{ error }}</span>{% endfor %}
+    </div>
+    <div class="form-group">
+      {{ form.focus_description.label }}<br>
+      {{ form.focus_description(class="input") }}
+      {% for error in form.focus_description.errors %}<span class="error">{{ error }}</span>{% endfor %}
     </div>
     {{ form.submit(class="btn") }}
   </form>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -297,6 +297,8 @@ def test_update_settings(logged_in_user, test_app):
     resp = logged_in_user.post(url_for('main.settings'), data={
         'preferred_work_minutes': '30',
         'productivity_goal': 'Write more code',
+        'daily_focus_goal': '120',
+        'focus_description': 'Study Python',
         'submit': True
     }, follow_redirects=True)
     assert resp.status_code == 200
@@ -305,3 +307,5 @@ def test_update_settings(logged_in_user, test_app):
         user = User.query.filter_by(email='test@example.com').first()
         assert user.preferred_work_minutes == 30
         assert user.productivity_goal == 'Write more code'
+        assert user.daily_focus_goal == 120
+        assert user.focus_description == 'Study Python'


### PR DESCRIPTION
## Summary
- rename the "Settings" nav item to **AI Profile**
- describe the purpose of the settings for the AI assistant
- add `daily_focus_goal` and `focus_description` fields
- update user model, form, route and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877842dd5e0832e82948fe261fd1c8c