### PR TITLE
Enable AI assistant chat on additional pages

### DIFF
--- a/pomodoro_app/templates/main/leaderboard.html
+++ b/pomodoro_app/templates/main/leaderboard.html
@@ -15,4 +15,9 @@
     {% endfor %}
     </tbody>
   </table>
+
+  <!-- AI Assistant Chat Widget -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+  <script src="{{ url_for('static', filename='js/agent_chat.js') }}" defer></script>
 {% endblock %}

--- a/pomodoro_app/templates/main/my_data.html
+++ b/pomodoro_app/templates/main/my_data.html
@@ -29,4 +29,9 @@
   {% else %}
     <p>No chat history stored.</p>
   {% endif %}
+
+  <!-- AI Assistant Chat Widget -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+  <script src="{{ url_for('static', filename='js/agent_chat.js') }}" defer></script>
 {% endblock %}

--- a/pomodoro_app/templates/main/settings.html
+++ b/pomodoro_app/templates/main/settings.html
@@ -29,4 +29,9 @@
     </div>
     {{ form.submit(class="btn") }}
   </form>
+
+  <!-- AI Assistant Chat Widget -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+  <script src="{{ url_for('static', filename='js/agent_chat.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load agent chat widget on My Data
- load agent chat widget on AI Profile
- load agent chat widget on Leaderboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c1e4a988832eab799516a147959b