### PR TITLE
Add CLI for secret key generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 FLASK_APP=pomodoro_app:create_app
 FLASK_ENV=development
 FLASK_CONFIG=development
-SECRET_KEY=change-me
+# SECRET_KEY for local development only.
+# NEVER deploy with this value. Generate your own with:
+#   flask secrets generate-key
+SECRET_KEY=dev-secret-key-CHANGE_ME
 DATABASE_URL=sqlite:///pomodoro.db
 OPENAI_API_KEY=your_openai_key_here
 LOGGING_LEVEL=INFO

--- a/README.txt
+++ b/README.txt
@@ -62,6 +62,9 @@ Installation:
    export FLASK_APP=pomodoro_app:create_app
    export FLASK_ENV=development
    export SECRET_KEY='your-very-secret-flask-key' # IMPORTANT: Set a strong secret key
+   # Never deploy with the sample SECRET_KEY.
+   # Generate at least 32 random bytes using:
+   #   flask secrets generate-key
    export DATABASE_URL='sqlite:///pomodoro.db' # Or your preferred DB connection string
    export OPENAI_API_KEY='your_openai_api_key_here' # Add your OpenAI key (required for chat feature)
 

--- a/pomodoro_app/__init__.py
+++ b/pomodoro_app/__init__.py
@@ -180,7 +180,8 @@ def create_app(config_name=None):
             'chat_enabled': app.config.get('FEATURE_CHAT_ENABLED', False)
         }
 
-    # Register CLI commands for managing agent personas
-    from .cli import personas as personas_cli
+    # Register CLI commands
+    from .cli import personas as personas_cli, secrets as secrets_cli
     app.cli.add_command(personas_cli)
+    app.cli.add_command(secrets_cli)
     return app

--- a/pomodoro_app/cli.py
+++ b/pomodoro_app/cli.py
@@ -1,4 +1,6 @@
+import os
 import json
+import base64
 import click
 from flask.cli import with_appcontext
 from .agent_config import load_personas, save_personas
@@ -29,3 +31,18 @@ def set_persona(name, prompt, voice):
     data[name] = {'prompt': prompt, 'voice': voice}
     save_personas(data)
     click.echo(f"Persona '{name}' saved.")
+
+
+@click.group()
+def secrets():
+    """Secret key utilities."""
+    pass
+
+
+@secrets.command('generate-key')
+@click.option('--bytes', 'num_bytes', default=32, show_default=True,
+              help='Number of random bytes to use')
+def generate_key(num_bytes):
+    """Generate a base64-encoded SECRET_KEY."""
+    key = base64.b64encode(os.urandom(num_bytes)).decode()
+    click.echo(key)


### PR DESCRIPTION
## Summary
- add `flask secrets generate-key` command
- register `secrets` CLI group in the app
- warn about using sample SECRET_KEY in README and `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c605b96c832e9d97f2e5a5d3ed9b