### PR TITLE
Sync running timer state

### DIFF
--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -205,6 +205,11 @@ body.dark-theme {
   margin-right: 1em;
 }
 
+.global-timer-wrapper {
+  text-align: center;
+  margin-top: 0.3em;
+}
+
 /* Container */
 .container {
   max-width: 960px;

--- a/pomodoro_app/templates/base.html
+++ b/pomodoro_app/templates/base.html
@@ -30,10 +30,13 @@
           <a href="{{ url_for('auth.register') }}">Register</a>
         {% endif %}
       </div>
-      <span id="global-timer-display" class="nav-timer"></span>
       <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">🌙</button>
     </div>
   </nav>
+
+  <div class="global-timer-wrapper">
+    <span id="global-timer-display" class="nav-timer"></span>
+  </div>
 
   {# show banner if chat disabled #}
   {% if not chat_enabled %}


### PR DESCRIPTION
## Summary
- sync into running phase instead of forced pause if server active but local state invalid
- start ticking immediately after syncing running state
- allow startCountdown to resume running state without server call
- relocate global timer display below navbar and style wrapper
- refetch state before auto-completing in global timer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f46a6d24832ea616183d5d721205