### PR TITLE
Remove complete button from floating timer

### DIFF
--- a/pomodoro_app/static/js/global_timer_widget.js
+++ b/pomodoro_app/static/js/global_timer_widget.js
@@ -46,7 +46,6 @@
       '  <div class="global-timer-actions">',
       '    <button type="button" id="global-timerbox-pause">Pause</button>',
       '    <button type="button" id="global-timerbox-resume" style="display:none;">Resume</button>',
-      '    <button type="button" id="global-timerbox-complete">Complete</button>',
       '    <button type="button" id="global-timerbox-reset">Reset</button>',
       '    <button type="button" id="global-timerbox-open">Open Timer</button>',
       '  </div>',
@@ -67,7 +66,6 @@
     });
     document.getElementById('global-timerbox-pause').addEventListener('click', doPause);
     document.getElementById('global-timerbox-resume').addEventListener('click', doResume);
-    document.getElementById('global-timerbox-complete').addEventListener('click', doComplete);
     document.getElementById('global-timerbox-reset').addEventListener('click', doReset);
   }
 
@@ -147,19 +145,19 @@
       pauseBtn.style.display='';
       pauseBtn.disabled=false;
       resumeBtn.style.display='none';
-      completeBtn.disabled=false;
+      if(completeBtn) completeBtn.disabled=false;
       resetBtn.disabled=false;
     } else if(phase==='paused'){
       pauseBtn.style.display='none';
       resumeBtn.style.display='';
       resumeBtn.disabled=false;
-      completeBtn.disabled=true;
+      if(completeBtn) completeBtn.disabled=true;
       resetBtn.disabled=false;
     } else {
       pauseBtn.style.display='';
       pauseBtn.disabled=true;
       resumeBtn.style.display='none';
-      completeBtn.disabled=true;
+      if(completeBtn) completeBtn.disabled=true;
       resetBtn.disabled=true;
     }
   }


### PR DESCRIPTION
## Summary
- remove the `Complete` button from the global timer widget
- gracefully handle absence of the button in the button update logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878394ddd0c832eb45a1166723d547f