### PR TITLE
Clean up audio files on startup

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,7 @@ Features:
 - Live Countdown Timer: An interactive, JavaScript-powered timer with audio notifications.
 - Responsive Design: Clean, mobile-friendly layout built with HTML and CSS.
 - Modular Structure: Organized using Flask Blueprints for authentication and main app functionality.
+- Automatic cleanup of old AI-generated audio files (configurable with MAX_AUDIO_FILE_AGE).
 
 Project Structure:
 pomodoro_app/
@@ -67,6 +68,7 @@ Installation:
    #   flask secrets generate-key
    export DATABASE_URL='sqlite:///pomodoro.db' # Or your preferred DB connection string
    export OPENAI_API_KEY='your_openai_api_key_here' # Add your OpenAI key (required for chat feature)
+   export MAX_AUDIO_FILE_AGE=3600  # Optional: age in seconds for cleaning old agent audio
 
 5. Initialize the Database:
    The app will create the SQLite database (pomodoro.db) on first run, or run:

--- a/pomodoro_app/__init__.py
+++ b/pomodoro_app/__init__.py
@@ -69,6 +69,13 @@ def create_app(config_name=None):
     limiter.init_app(app)
     csrf.init_app(app)
 
+    from pomodoro_app.main.api_routes import cleanup_old_agent_audio_files
+    # --- Clean up temporary agent audio files ---
+    with app.app_context():
+        cleanup_old_agent_audio_files(
+            app.config.get('MAX_AUDIO_FILE_AGE', 3600)
+        )
+
     # Disable rate limiting if testing
     # (Keep existing code) ...
     if app.config.get('TESTING', False) and not app.config.get('RATELIMIT_ENABLED', True):


### PR DESCRIPTION
## Summary
- call `cleanup_old_agent_audio_files` at startup
- document the `MAX_AUDIO_FILE_AGE` config value in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687932ad3318832e9469f3c20ce010ef