### PR TITLE
Add production secret key validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -109,6 +109,14 @@ class ProductionConfig(Config):
         for req in required_vars:
             validated_vars[req] = self._assert(req)
 
+        # Fail if using the development default secret key in production
+        secret_key = validated_vars["SECRET_KEY"]
+        if secret_key == DevelopmentConfig.SECRET_KEY:
+            raise RuntimeError("Production SECRET_KEY matches development default")
+        # Ensure the runtime SECRET_KEY value is stored on the instance so
+        # app.config.from_object picks it up
+        self.SECRET_KEY = secret_key
+
         # --- Set the Redis URL specifically for production ---
         # Retrieve the validated REDIS_URL environment variable
         redis_url = validated_vars["REDIS_URL"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+from pomodoro_app import create_app
+from config import DevelopmentConfig
+
+
+def test_production_raises_on_default_secret(monkeypatch):
+    monkeypatch.setenv('SECRET_KEY', DevelopmentConfig.SECRET_KEY)
+    monkeypatch.setenv('DATABASE_URL', 'sqlite:///dummy.db')
+    monkeypatch.setenv('REDIS_URL', 'redis://localhost:6379/0')
+    with pytest.raises(SystemExit):
+        create_app('production')


### PR DESCRIPTION
## Summary
- enforce a check in `ProductionConfig.__init__` to prevent using the development `SECRET_KEY`
- add a unit test to verify `create_app('production')` exits if the production key equals the dev default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879326cd890832e80bac737fff91e54