### PR TITLE
Normalize postgres URLs in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -75,6 +75,13 @@ class Config:
             parsed = parsed._replace(netloc=netloc)
         return urlunparse(parsed)
 
+    @staticmethod
+    def _normalize_database_url(url: str) -> str:
+        """Convert postgres:// URLs to postgresql:// for SQLAlchemy."""
+        if url and url.startswith("postgres://"):
+            url = url.replace("postgres://", "postgresql://", 1)
+        return url
+
 
 class DevelopmentConfig(Config):
     """Development configuration."""
@@ -83,10 +90,10 @@ class DevelopmentConfig(Config):
     # +++ ADDED BACK: Fallback SECRET_KEY specifically for development +++
     SECRET_KEY = os.environ.get('SECRET_KEY', 'default-dev-secret-key-CHANGE-ME')
     # +++ ADDED BACK: Use a separate fallback DB for development +++
-    SQLALCHEMY_DATABASE_URI = os.environ.get(
+    SQLALCHEMY_DATABASE_URI = Config._normalize_database_url(os.environ.get(
         'DATABASE_URL',
         'sqlite:///' + os.path.join(basedir, 'pomodoro_app', 'pomodoro-dev.db')
-    )
+    ))
     # Less strict rate limits for development/testing
     RATELIMIT_DEFAULT = "500 per day;100 per hour;20 per minute"
     # Development uses memory by default unless RATELIMIT_STORAGE_URI is set via env var
@@ -96,6 +103,7 @@ class ProductionConfig(Config):
     """Production configuration."""
     FLASK_ENV = 'production'
     DEBUG = False
+    SQLALCHEMY_DATABASE_URI = Config._normalize_database_url(os.environ.get('DATABASE_URL'))
     # Production rate limits (can still be overridden by RATELIMIT_DEFAULT env var)
     RATELIMIT_DEFAULT = "200 per day;50 per hour" # Explicitly set standard limits
 
@@ -130,7 +138,7 @@ class TestingConfig(Config):
     TESTING = True
     DEBUG = True
     # Use in-memory SQLite database for tests or a dedicated test file
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    SQLALCHEMY_DATABASE_URI = Config._normalize_database_url('sqlite:///:memory:')
     WTF_CSRF_ENABLED = False  # Disable CSRF for testing forms
     SECRET_KEY = 'test-secret-key' # Explicitly set for tests, overrides base
     # Disable rate limiting for tests usually

--- a/tests/test_config_db_url.py
+++ b/tests/test_config_db_url.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+import sys
+
+
+def get_database_uri(config_name, url):
+    env = os.environ.copy()
+    env['DATABASE_URL'] = url
+    env.setdefault('SECRET_KEY', 'test-secret-key')
+    env.setdefault('REDIS_URL', 'redis://localhost:6379/0')
+    code = (
+        "import pomodoro_app, json;"
+        f"app=pomodoro_app.create_app('{config_name}');"
+        "print(app.config['SQLALCHEMY_DATABASE_URI'])"
+    )
+    result = subprocess.check_output([sys.executable, '-c', code], env=env, text=True)
+    # Last line should contain the URI
+    return result.strip().splitlines()[-1]
+
+
+def test_postgres_scheme_normalized():
+    uri = get_database_uri('development', 'postgres://u:p@localhost/db')
+    assert uri == 'postgresql://u:p@localhost/db'
+
+
+def test_postgres_scheme_normalized_production():
+    uri = get_database_uri('production', 'postgres://u:p@localhost/db')
+    assert uri == 'postgresql://u:p@localhost/db'
+
+
+def test_postgresql_scheme_unchanged():
+    uri = get_database_uri('development', 'postgresql://u:p@localhost/db')
+    assert uri == 'postgresql://u:p@localhost/db'


### PR DESCRIPTION
## Summary
- add `Config._normalize_database_url` helper
- normalize database URLs in development, production and testing configs
- test old and new postgres URL schemes

## Testing
- `pytest -q tests/test_config_db_url.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793293c920832eb8c4b43724012331