### PR TITLE
Improve AI profile documentation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -88,6 +88,17 @@ Usage:
 - View Analytics: Check the Dashboard for session statistics.
 - Chat (Optional): If configured, interact with the AI assistant on the dashboard.
 
+AI Profile
+----------
+Use the **Settings** page to configure your AI profile. These values help the assistant tailor its responses to you:
+
+- **Preferred Work Minutes**: Default length of a focused work block. The timer uses this when you start a new session.
+- **Productivity Goal**: Short statement describing what you want to achieve overall. The AI refers to this when giving encouragement.
+- **Daily Focus Goal (minutes)**: Optional daily target for time spent in focus mode. Helpful for tracking progress.
+- **Focus Description**: Optional details about what you intend to focus on today or this week.
+
+The AI assistant reads these fields to provide more relevant suggestions during chats and in motivational prompts.
+
 Running Tests:
   pytest
   # The tests use the built-in TestingConfig and do not require any

--- a/config.py
+++ b/config.py
@@ -130,7 +130,10 @@ class ProductionConfig(Config):
 
         # Fail if using the development default secret key in production
         secret_key = validated_vars["SECRET_KEY"]
-        if secret_key == DevelopmentConfig.SECRET_KEY:
+        # Compare to the literal development default rather than the
+        # DevelopmentConfig.SECRET_KEY attribute, which may be overridden by
+        # the environment at import time.
+        if secret_key == 'default-dev-secret-key-CHANGE-ME':
             raise RuntimeError("Production SECRET_KEY matches development default")
         # Ensure the runtime SECRET_KEY value is stored on the instance so
         # app.config.from_object picks it up

--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -266,6 +266,13 @@ body.dark-theme {
     margin-top: 0.3em;
     display: block;
 }
+/* Optional helper text shown under form fields */
+.form-help {
+  font-size: 0.9em;
+  color: #6c757d;
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
+}
 
 .btn {
   padding: 0.6em 1.5em;

--- a/pomodoro_app/templates/main/settings.html
+++ b/pomodoro_app/templates/main/settings.html
@@ -10,21 +10,25 @@
     <div class="form-group">
       {{ form.preferred_work_minutes.label }}<br>
       {{ form.preferred_work_minutes(class="input") }}
+      <p class="form-help">How long a single focus session should last by default.</p>
       {% for error in form.preferred_work_minutes.errors %}<span class="error">{{ error }}</span>{% endfor %}
     </div>
     <div class="form-group">
       {{ form.productivity_goal.label }}<br>
       {{ form.productivity_goal(class="input") }}
+      <p class="form-help">A short phrase describing your overarching objective.</p>
       {% for error in form.productivity_goal.errors %}<span class="error">{{ error }}</span>{% endfor %}
     </div>
     <div class="form-group">
       {{ form.daily_focus_goal.label }}<br>
       {{ form.daily_focus_goal(class="input") }}
+      <p class="form-help">Optional target for minutes of focused work per day.</p>
       {% for error in form.daily_focus_goal.errors %}<span class="error">{{ error }}</span>{% endfor %}
     </div>
     <div class="form-group">
       {{ form.focus_description.label }}<br>
       {{ form.focus_description(class="input") }}
+      <p class="form-help">Any extra notes about what you're concentrating on.</p>
       {% for error in form.focus_description.errors %}<span class="error">{{ error }}</span>{% endfor %}
     </div>
     {{ form.submit(class="btn") }}


### PR DESCRIPTION
## Summary
- clarify secret key check for ProductionConfig
- add explanations for AI profile fields in Settings page
- show small helper text under profile fields
- document AI profile usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e59b446a8832eaa3c418e0abffda3