### PR TITLE
Add sessions chart to dashboard

### DIFF
--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -206,6 +206,15 @@ def dashboard():
     chat_enabled = current_app.config.get('FEATURE_CHAT_ENABLED', False)
     current_app.logger.debug(f"Dashboard: Rendering for User {user_id}. Chat enabled: {chat_enabled}")
 
+    sessions_data = [
+        {
+            'timestamp': sess.timestamp.isoformat() if sess.timestamp else '',
+            'work_duration': sess.work_duration,
+            'break_duration': sess.break_duration,
+        }
+        for sess in aware_sessions
+    ]
+
     return render_template('main/dashboard.html',
                            total_points=total_points,
                            total_focus=total_focus,
@@ -217,7 +226,8 @@ def dashboard():
                            week_focus=week_focus,
                            week_sessions=week_sessions,
                            week_points=week_points,
-                           sessions=aware_sessions, # Pass the potentially timezone-aware sessions
+                           sessions=aware_sessions,  # For table display
+                           sessions_data=sessions_data,  # JSON-serializable list
                            chat_enabled=chat_enabled)
 
 

--- a/pomodoro_app/static/js/dashboard.js
+++ b/pomodoro_app/static/js/dashboard.js
@@ -36,6 +36,77 @@ document.addEventListener('DOMContentLoaded', function() {
     // All chat functionality is now handled by the global agent_chat.js script,
     // which creates a floating widget.
 
+
+    // --- Sessions Chart ---
+    const sessionsData = window.sessionHistory || [];
+    if (sessionsData.length && window.Chart) {
+        const ctx = document.getElementById('sessions-chart').getContext('2d');
+
+        function buildChartColors(theme) {
+            const dark = theme === 'dark';
+            return {
+                work: dark ? '#4dc9f6' : '#007bff',
+                break: dark ? '#a4e786' : '#28a745',
+                text: dark ? '#e9e9e9' : '#212529'
+            };
+        }
+
+        let colors = buildChartColors(document.body.classList.contains('dark-theme') ? 'dark' : 'light');
+
+        const labels = sessionsData.slice().reverse().map(s => {
+            const d = new Date(s.timestamp);
+            return d.toLocaleDateString();
+        });
+        const workDur = sessionsData.slice().reverse().map(s => s.work_duration);
+        const breakDur = sessionsData.slice().reverse().map(s => s.break_duration);
+
+        const chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: 'Work (min)',
+                        data: workDur,
+                        borderColor: colors.work,
+                        backgroundColor: colors.work,
+                        tension: 0.1
+                    },
+                    {
+                        label: 'Break (min)',
+                        data: breakDur,
+                        borderColor: colors.break,
+                        backgroundColor: colors.break,
+                        tension: 0.1
+                    }
+                ]
+            },
+            options: {
+                maintainAspectRatio: false,
+                scales: {
+                    y: { beginAtZero: true, ticks: { color: colors.text } },
+                    x: { ticks: { color: colors.text } }
+                },
+                plugins: {
+                    legend: { labels: { color: colors.text } }
+                }
+            }
+        });
+
+        // Update chart colors when theme changes
+        document.body.addEventListener('themechange', (e) => {
+            colors = buildChartColors(e.detail);
+            chart.options.scales.x.ticks.color = colors.text;
+            chart.options.scales.y.ticks.color = colors.text;
+            chart.options.plugins.legend.labels.color = colors.text;
+            chart.data.datasets[0].borderColor = colors.work;
+            chart.data.datasets[0].backgroundColor = colors.work;
+            chart.data.datasets[1].borderColor = colors.break;
+            chart.data.datasets[1].backgroundColor = colors.break;
+            chart.update();
+        });
+    }
+
     console.log("Dashboard timestamp formatting applied.");
 
 }); // end DOMContentLoaded

--- a/pomodoro_app/static/js/theme_toggle.js
+++ b/pomodoro_app/static/js/theme_toggle.js
@@ -11,6 +11,8 @@
       document.body.classList.remove('dark-theme');
       toggleBtn.textContent = '🌙';
     }
+    // Notify listeners (e.g., dashboard chart) of the theme change
+    document.body.dispatchEvent(new CustomEvent('themechange', { detail: theme }));
   }
 
   const stored = localStorage.getItem('theme');

--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -551,6 +551,12 @@ body.dark-theme {
   margin-bottom: 2em;
   border-radius: 5px;
 }
+#sessions-chart-container {
+  margin: 2em auto;
+  max-width: 600px;
+  position: relative;
+  height: 300px;
+}
 .sessions-table {
   width: 100%;
   border-collapse: collapse;
@@ -860,6 +866,9 @@ body.dark-theme .sessions-table td {
 }
 body.dark-theme .sessions-table tr:nth-child(even) {
   background: #1a1a1a;
+}
+body.dark-theme #sessions-chart-container {
+  background: #1e1e1e;
 }
 body.dark-theme .chat-log {
   background-color: #1e1e1e;

--- a/pomodoro_app/templates/main/dashboard.html
+++ b/pomodoro_app/templates/main/dashboard.html
@@ -69,6 +69,9 @@
         </tbody>
       </table>
     </div>
+    <div id="sessions-chart-container">
+      <canvas id="sessions-chart" height="300"></canvas>
+    </div>
   {% else %}
     <p>No sessions recorded yet. <a href="{{ url_for('main.timer') }}">Start your first Pomodoro!</a></p>
   {% endif %}
@@ -76,6 +79,11 @@
   {# Load libs for chat widget #}
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
+
+  <script>
+    window.sessionHistory = {{ sessions_data|tojson }};
+  </script>
 
   {# Removed unused ttsGloballyEnabled flag #}
   <script>

--- a/tests/test_config_db_url.py
+++ b/tests/test_config_db_url.py
@@ -6,10 +6,13 @@ import sys
 def get_database_uri(config_name, url):
     env = os.environ.copy()
     env['DATABASE_URL'] = url
-    env.setdefault('SECRET_KEY', 'test-secret-key')
     env.setdefault('REDIS_URL', 'redis://localhost:6379/0')
+    # Avoid setting SECRET_KEY in the environment so DevelopmentConfig
+    # keeps its default value. Instead set it inside the Python command
+    # prior to creating the app.
     code = (
-        "import pomodoro_app, json;"
+        "import pomodoro_app, os, json;"
+        "os.environ['SECRET_KEY']='test-config-secret';"
         f"app=pomodoro_app.create_app('{config_name}');"
         "print(app.config['SQLALCHEMY_DATABASE_URI'])"
     )


### PR DESCRIPTION
## Summary
- extend theme toggle script to emit `themechange` events
- provide JSON-safe sessions data in dashboard route
- display a chart of recent sessions on the dashboard
- update dashboard styles for chart container and dark theme
- support Chart.js theme switching in dashboard JS
- fix test helper to set `SECRET_KEY` after import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5a2a49bc832e9d4e24710ca18f59