### PR TITLE
Fix CSP for Chart.js on dashboard

### DIFF
--- a/pomodoro_app/__init__.py
+++ b/pomodoro_app/__init__.py
@@ -101,7 +101,7 @@ def create_app(config_name=None):
         # - frame-ancestors 'none': Prevents the site from being embedded in iframes (clickjacking protection).
         csp = (
             "default-src 'self'; "
-            "script-src 'self' https://cdn.jsdelivr.net; " # For Marked/DOMPurify CDN
+            "script-src 'self' https://cdn.jsdelivr.net 'unsafe-eval'; " # For Marked/DOMPurify CDN and Chart.js
             "style-src 'self' 'unsafe-inline'; "          # For local CSS and injected chat styles
             "img-src 'self' data:; "                       # Allows local images and data URIs
             "object-src 'none'; "                          # Disallow plugins (Flash, etc.)


### PR DESCRIPTION
## Summary
- relax CSP script-src directive so chart can initialize
- install psycopg2-binary for tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e74b43100832ea0e1c8943b9e5c51