### PR TITLE
Remove dashboard graph

### DIFF
--- a/pomodoro_app/__init__.py
+++ b/pomodoro_app/__init__.py
@@ -101,14 +101,11 @@ def create_app(config_name=None):
         # - frame-ancestors 'none': Prevents the site from being embedded in iframes (clickjacking protection).
         csp = (
             "default-src 'self'; "
-            "script-src 'self' https://cdn.jsdelivr.net 'unsafe-eval'; "  # Allow Chart.js
-            "script-src 'self' https://cdn.jsdelivr.net; "  # Allow CDN scripts like Chartist
-            "script-src 'self' https://cdn.jsdelivr.net; "  # CDN scripts allowed, strict CSP build of Chart.js
-            "script-src 'self' https://cdn.jsdelivr.net 'unsafe-eval'; " # For Marked/DOMPurify CDN and Chart.js
-            "style-src 'self' 'unsafe-inline'; "          # For local CSS and injected chat styles
-            "img-src 'self' data:; "                       # Allows local images and data URIs
-            "object-src 'none'; "                          # Disallow plugins (Flash, etc.)
-            "frame-ancestors 'none'; "                     # Prevent clickjacking
+            "script-src 'self' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data:; "
+            "object-src 'none'; "
+            "frame-ancestors 'none'; "
             # Add other directives as needed (e.g., font-src, connect-src, media-src)
             # If you load fonts from Google Fonts, add: font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
         )

--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -216,17 +216,6 @@ def dashboard():
         for sess in aware_sessions
     ]
 
-    start_week_date = start_of_week_utc.date()
-    week_dates = [start_week_date + timedelta(days=i) for i in range(7)]
-    daily_points = {d: 0 for d in week_dates}
-    for sess in aware_sessions:
-        if sess.timestamp and sess.timestamp >= start_of_week_utc:
-            day = sess.timestamp.date()
-            if day in daily_points:
-                daily_points[day] += sess.points_earned or 0
-    week_points_series = [
-        {'date': d.isoformat(), 'points': daily_points[d]} for d in week_dates
-    ]
 
     return render_template('main/dashboard.html',
                            total_points=total_points,
@@ -241,7 +230,6 @@ def dashboard():
                            week_points=week_points,
                            sessions=aware_sessions,  # For table display
                            sessions_data=sessions_data,  # JSON-serializable list
-                           week_points_series=week_points_series,
                            chat_enabled=chat_enabled)
 
 

--- a/pomodoro_app/static/js/dashboard.js
+++ b/pomodoro_app/static/js/dashboard.js
@@ -1,5 +1,5 @@
 // static/js/dashboard.js
-// Handles timestamp localisation and draws two Chart.js charts.
+// Handles timestamp localisation for dashboard tables.
 
 document.addEventListener('DOMContentLoaded', () => {
   console.log('Dashboard JS loaded');
@@ -16,62 +16,5 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  /* ---------- 2. Weekly points line chart ---------- */
-  const weekPoints = window.weekPoints || [];               // [{date, points}, …]
-  if (weekPoints.length && window.Chart) {
-    const ctx     = document.getElementById('sessions-chart').getContext('2d');
-    const labels  = weekPoints.map(p =>
-      new Date(p.date).toLocaleDateString(undefined, { weekday: 'short' })
-    );
-    const data    = weekPoints.map(p => p.points);
-
-    const themeColors = t =>
-      t === 'dark'
-        ? { line: '#4dc9f6', text: '#e9e9e9' }
-        : { line: '#007bff', text: '#212529' };
-
-    const colors = themeColors(document.body.classList.contains('dark-theme') ? 'dark' : 'light');
-
-    const pointsChart = new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels,
-        datasets: [{
-          label: 'Points',
-          data,
-          borderColor: colors.line,
-          backgroundColor: colors.line,
-          tension: 0.25,
-          fill: false
-        }]
-      },
-      options: {
-        maintainAspectRatio: false,
-        scales: {
-          x: { ticks: { color: colors.text } },
-          y: { beginAtZero: true, ticks: { color: colors.text } }
-        },
-        plugins: {
-          legend: { labels: { color: colors.text } },
-          tooltip: { intersect: false }
-        }
-      }
-    });
-
-    // live‑update colours when user toggles theme
-    document.body.addEventListener('themechange', e => {
-      const c = themeColors(e.detail);
-      const ds = pointsChart.data.datasets[0];
-      ds.borderColor = ds.backgroundColor = c.line;
-      pointsChart.options.scales.x.ticks.color           = c.text;
-      pointsChart.options.scales.y.ticks.color           = c.text;
-      pointsChart.options.plugins.legend.labels.color    = c.text;
-      pointsChart.update();
-    });
-  }
-
-  /* ---------- 3. Session history bar chart (optional) ---------- */
-  // If you still want a second chart, either:
-  //  - load Chart.js again with a different canvas, OR
-  //  - keep Chartist, but then ALSO load its CSS+JS in the template
+  // (Graph functionality removed)
 });

--- a/pomodoro_app/static/js/theme_toggle.js
+++ b/pomodoro_app/static/js/theme_toggle.js
@@ -11,7 +11,7 @@
       document.body.classList.remove('dark-theme');
       toggleBtn.textContent = '🌙';
     }
-    // Notify listeners (e.g., dashboard chart) of the theme change
+    // Notify listeners of the theme change
     document.body.dispatchEvent(new CustomEvent('themechange', { detail: theme }));
   }
 

--- a/pomodoro_app/static/style.css
+++ b/pomodoro_app/static/style.css
@@ -558,13 +558,6 @@ body.dark-theme {
   margin-bottom: 2em;
   border-radius: 5px;
 }
-#sessions-chart-container {
-  margin: 2em auto;
-  max-width: 600px;
-  width: 100%;
-  position: relative;
-  height: 300px;
-}
 .sessions-table {
   width: 100%;
   border-collapse: collapse;
@@ -874,10 +867,6 @@ body.dark-theme .sessions-table td {
 }
 body.dark-theme .sessions-table tr:nth-child(even) {
   background: #1a1a1a;
-}
-body.dark-theme #sessions-chart-container {
-  background: #1e1e1e;
-  width: 100%;
 }
 body.dark-theme .chat-log {
   background-color: #1e1e1e;

--- a/pomodoro_app/templates/main/dashboard.html
+++ b/pomodoro_app/templates/main/dashboard.html
@@ -69,9 +69,6 @@
         </tbody>
       </table>
     </div>
-    <div id="sessions-chart-container">
-      <canvas id="sessions-chart" aria-label="Weekly points chart"></canvas>
-    </div>
   {% else %}
     <p>No sessions recorded yet. <a href="{{ url_for('main.timer') }}">Start your first Pomodoro!</a></p>
   {% endif %}
@@ -82,7 +79,6 @@
 
   <script>
     window.sessionHistory = {{ sessions_data|tojson }};
-    window.weekPoints = {{ week_points_series|tojson }};
   </script>
 
   {# Removed unused ttsGloballyEnabled flag #}
@@ -93,7 +89,6 @@
   </script>
   <script src="{{ url_for('static', filename='js/agent_chat.js') }}" defer></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="{{ url_for('static', filename='js/dashboard.js') }}" defer></script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- drop chart container from dashboard and remove week graph data
- stop loading Chart.js
- simplify CSP policy and JavaScript now that no charts are drawn
- clean up unused styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebca92828832e80e4cfcf285ff9a9