### PR TITLE
Add weekly points chart

### DIFF
--- a/pomodoro_app/static/js/dashboard.js
+++ b/pomodoro_app/static/js/dashboard.js
@@ -8,13 +8,82 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.local-timestamp').forEach(cell => {
     const iso = cell.dataset.timestamp;
     if (!iso) return;
-    const d   = new Date(iso);
+    const d = new Date(iso);
     if (Number.isNaN(d)) return;
     cell.textContent = d.toLocaleString(undefined, {
-      year: 'numeric', month: 'short', day: 'numeric',
-      hour: 'numeric', minute: '2-digit'
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit'
     });
   });
 
-  // (Graph functionality removed)
+  /* ---------- 2. Points‑per‑day chart ---------- */
+  buildPointsWeekChart();
 });
+
+function buildPointsWeekChart() {
+  const canvas = document.getElementById('points-week-chart');
+  if (!canvas || typeof Chart === 'undefined') return;
+
+  // Gather session history supplied by Flask → Jinja → JS
+  const sessions = window.sessionHistory || [];
+
+  // Prepare buckets for the last 7 days (today – 6)
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const now    = new Date();
+  const buckets = [];        // [{label:'Mon', iso:'yyyy-mm-dd', points:0}, …]
+
+  // Walk backwards 6 days so graph reads chronologically left→right
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * DAY_MS);
+    const iso = d.toISOString().slice(0, 10);              // YYYY‑MM‑DD
+    buckets.push({
+      label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+      iso,
+      points: 0
+    });
+  }
+
+  // Sum points into their day bucket
+  sessions.forEach(sess => {
+    if (!sess.timestamp) return;
+    const isoDay = new Date(sess.timestamp).toISOString().slice(0, 10);
+    const bucket = buckets.find(b => b.iso === isoDay);
+    if (bucket) bucket.points += (sess.points_earned || 0);
+  });
+
+  const labels = buckets.map(b => b.label);
+  const data   = buckets.map(b => b.points);
+
+  new Chart(canvas, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Points',
+        data,
+        fill: true,
+        tension: 0.35,
+        borderWidth: 2,
+        // rely on Chart.js automatic colour cycle – looks nice in both themes
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: { label: ctx => `${ctx.parsed.y} pts` }
+        }
+      },
+      scales: {
+        y: { beginAtZero: true, ticks: { precision: 0 } }
+      }
+    }
+  });
+
+  /* ---------- 3. Theme‑sync (dark / light) ---------- */
+  document.body.addEventListener('themechange', () => Chart.helpers.each(Chart.instances, c => c.resize()));
+}

--- a/pomodoro_app/templates/main/dashboard.html
+++ b/pomodoro_app/templates/main/dashboard.html
@@ -48,6 +48,10 @@
     </div>
   </div>
 
+# ---------------- Points‑per‑Day chart ----------------
+  <h3 class="dashboard-section-title">Points Earned – Last 7 Days</h3>
+  <canvas id="points-week-chart" style="max-width:100%;height:320px;"></canvas>
+
   <h3 class="dashboard-section-title">Past Sessions</h3>
   {% if sessions %}
     <div class="sessions-table-container">
@@ -76,6 +80,8 @@
   {# Load libs for chat widget #}
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+  <!-- Chart.js for the points‑per‑day graph -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 
   <script>
     window.sessionHistory = {{ sessions_data|tojson }};


### PR DESCRIPTION
## Summary
- add a Chart.js line chart of points earned for the last 7 days
- load Chart.js from CDN
- compute points per day and render chart on dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec5112974832eaeacc297df601f43