### PR TITLE
Fix dashboard chart duplication

### DIFF
--- a/pomodoro_app/static/js/dashboard.js
+++ b/pomodoro_app/static/js/dashboard.js
@@ -54,7 +54,6 @@ function buildPointsWeekChart() {
     if (!bucket) return;
     const pts = Number(sess.points_earned);
     if (!Number.isNaN(pts)) bucket.points += pts;
-    if (bucket) bucket.points += (sess.points_earned || 0);
   });
 
   const labels = buckets.map(b => b.label);

--- a/pomodoro_app/templates/main/dashboard.html
+++ b/pomodoro_app/templates/main/dashboard.html
@@ -48,10 +48,6 @@
     </div>
   </div>
 
-# ---------------- Points‑per‑Day chart ----------------
-  <h3 class="dashboard-section-title">Points Earned – Last 7 Days</h3>
-  <canvas id="points-week-chart" style="max-width:100%;height:320px;"></canvas>
-
   <h3 class="dashboard-section-title">Past Sessions</h3>
   {% if sessions %}
     <div class="sessions-table-container">


### PR DESCRIPTION
## Summary
- remove extra Points Earned chart markup
- fix double counting in dashboard chart JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ecbc2fdc0832ebd082835c9859487