### PR TITLE
Fix weekly points chart summation

### DIFF
--- a/pomodoro_app/static/js/dashboard.js
+++ b/pomodoro_app/static/js/dashboard.js
@@ -48,12 +48,12 @@ function buildPointsWeekChart() {
 
   // Sum points into their day bucket
   sessions.forEach(sess => {
-    if (!sess.timestamp) return;
+    const pts = Number(sess.points_earned);
+    if (!sess.timestamp || !Number.isFinite(pts)) return;
+
     const isoDay = new Date(sess.timestamp).toISOString().slice(0, 10);
     const bucket = buckets.find(b => b.iso === isoDay);
-    if (!bucket) return;
-    const pts = Number(sess.points_earned);
-    if (!Number.isNaN(pts)) bucket.points += pts;
+    if (bucket) bucket.points += pts;     // one, and only one, increment
   });
 
   const labels = buckets.map(b => b.label);


### PR DESCRIPTION
## Summary
- refactor dashboard point summation so each day bucket increments once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ecd5ac270832ebb9b8abd7b6f59c7