### PR TITLE
Fix dashboard points graph

### DIFF
--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -208,7 +208,7 @@ def dashboard():
 
     sessions_data = [
         {
-            'timestamp': sess.timestamp.isoformat() if sess.timestamp else '',
+            'timestamp': sess.timestamp.isoformat(timespec='seconds') if sess.timestamp else '',
             'work_duration': sess.work_duration,
             'break_duration': sess.break_duration,
             'points_earned': sess.points_earned or 0,

--- a/pomodoro_app/static/js/dashboard.js
+++ b/pomodoro_app/static/js/dashboard.js
@@ -40,7 +40,7 @@ function buildPointsWeekChart() {
     const d = new Date(now.getTime() - i * DAY_MS);
     const iso = d.toISOString().slice(0, 10);              // YYYY‑MM‑DD
     buckets.push({
-      label: d.toLocaleDateString(undefined, { weekday: 'short' }),
+      label: d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' }),
       iso,
       points: 0
     });

--- a/pomodoro_app/templates/main/dashboard.html
+++ b/pomodoro_app/templates/main/dashboard.html
@@ -58,8 +58,8 @@
         <tbody>
           {% for sess in sessions %}
             <tr>
-              <td class="local-timestamp" data-timestamp="{{ sess.timestamp.isoformat() if sess.timestamp else '' }}">
-                 {% if sess.timestamp %}{{ sess.timestamp.isoformat() }}{% else %}N/A{% endif %}
+              <td class="local-timestamp" data-timestamp="{{ sess.timestamp.isoformat(timespec='seconds') if sess.timestamp else '' }}">
+                 {% if sess.timestamp %}{{ sess.timestamp.isoformat(timespec='seconds') }}{% else %}N/A{% endif %}
               </td>
               <td>{{ sess.work_duration }}</td>
               <td>{{ sess.break_duration }}</td>

--- a/pomodoro_app/templates/main/my_data.html
+++ b/pomodoro_app/templates/main/my_data.html
@@ -14,7 +14,7 @@
         <li class="chat-history-item {{ 'user-message' if msg.role == 'user' else 'assistant-message' }}">
           <div>
             <strong>{{ msg.role.title() }}</strong>
-            <em>{{ msg.timestamp.isoformat() if msg.timestamp else '' }}</em>
+            <em>{{ msg.timestamp.isoformat(timespec='seconds') if msg.timestamp else '' }}</em>
 
             {% if msg.role == 'user' %}
             <form action="{{ url_for('main.delete_message_pair', message_id=msg.id) }}"


### PR DESCRIPTION
## Summary
- ensure ISO timestamps omit microseconds for browser compatibility
- label dashboard chart using day and month

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed035658c832eba0c7ff86c8754c4