### PR TITLE
Fix CSP blocking inline scripts

### DIFF
--- a/pomodoro_app/__init__.py
+++ b/pomodoro_app/__init__.py
@@ -101,7 +101,7 @@ def create_app(config_name=None):
         # - frame-ancestors 'none': Prevents the site from being embedded in iframes (clickjacking protection).
         csp = (
             "default-src 'self'; "
-            "script-src 'self' https://cdn.jsdelivr.net; "
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data:; "
             "object-src 'none'; "


### PR DESCRIPTION
## Summary
- allow inline scripts in the Content Security Policy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881fc59cbc0832e8985fa83956f0992