### PR TITLE
Sync chat history on deletion

### DIFF
--- a/pomodoro_app/main/routes.py
+++ b/pomodoro_app/main/routes.py
@@ -249,15 +249,29 @@ def leaderboard():
 def my_data():
     """Show the user’s stored chat messages."""
     try:
-        messages = (ChatMessage.query
-                               .filter_by(user_id=current_user.id)
-                               .order_by(ChatMessage.timestamp.asc())
-                               .all())
+        messages = (
+            ChatMessage.query
+            .filter_by(user_id=current_user.id)
+            .order_by(ChatMessage.timestamp.asc())
+            .all()
+        )
     except SQLAlchemyError as e:
-        current_app.logger.error(f"MyData: DB error for user {current_user.id}: {e}")
+        current_app.logger.error(
+            f"MyData: DB error for user {current_user.id}: {e}"
+        )
         messages = []
 
-    return render_template('main/my_data.html', messages=messages)
+    messages_data = [
+        {
+            "sender": "ai" if m.role == "assistant" else "user",
+            "text": m.text,
+        }
+        for m in messages
+    ]
+
+    return render_template(
+        "main/my_data.html", messages=messages, messages_data=messages_data
+    )
 
 
 

--- a/pomodoro_app/templates/main/my_data.html
+++ b/pomodoro_app/templates/main/my_data.html
@@ -39,4 +39,14 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
   <script src="{{ url_for('static', filename='js/agent_chat.js') }}" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const history = {{ messages_data | tojson | safe }};
+      try {
+        sessionStorage.setItem('pomodoroAgentChatHistory_v1', JSON.stringify(history));
+      } catch (e) {
+        console.error('Failed to sync chat history', e);
+      }
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- sync chat history in sessionStorage with server data on My Data page
- provide chat history JSON from backend route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688214fd5aac832ea6dc6abac83b1af3